### PR TITLE
Show simple action success notification

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -213,11 +213,10 @@ export default function App() {
     setBusyId(id);
     setMessage(null);
     try {
-      const response = await sendAction(id, action, reason);
+      await sendAction(id, action, reason);
       setMessage({
         type: 'success',
-        text: `Action ${action.toUpperCase()} queued for ${id}`,
-        detail: response,
+        text: 'Action Success',
       });
     } catch (err) {
       setMessage({ type: 'error', text: err.message });


### PR DESCRIPTION
## Summary
- simplify the success alert after triggering an action so only a generic "Action Success" message is shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddc83978988329b505bb494ac243a3