### PR TITLE
Add device monitoring tab with Windows connectivity checks

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -24,6 +24,35 @@ header {
   margin-bottom: 2rem;
 }
 
+.tabs {
+  display: inline-flex;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.12);
+  padding: 0.25rem;
+}
+
+.tab {
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.tab:hover {
+  color: #e2e8f0;
+}
+
+.tab.active {
+  background: rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+
 h1 {
   margin: 0;
   font-size: 2rem;
@@ -60,6 +89,10 @@ table {
   border-collapse: collapse;
 }
 
+.device-table {
+  table-layout: fixed;
+}
+
 th,
 td {
   padding: 0.75rem 1rem;
@@ -87,6 +120,42 @@ tr + tr td {
   margin-top: 0.25rem;
   color: #94a3b8;
   font-size: 0.9rem;
+}
+
+.device-name {
+  font-weight: 600;
+}
+
+.device-description {
+  margin-top: 0.25rem;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.device-detail {
+  margin-top: 0.35rem;
+  color: #cbd5f5;
+  font-size: 0.85rem;
+}
+
+.device-address {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular,
+    Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.95rem;
+}
+
+.device-meta {
+  margin-top: 0.35rem;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.device-meta:first-of-type {
+  margin-top: 0.5rem;
+}
+
+.device-meta.subtle {
+  color: #64748b;
 }
 
 .service-detail {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -23,6 +23,12 @@ export async function fetchServices() {
   return data.services || [];
 }
 
+export async function fetchDevices() {
+  const response = await fetch(`${API_BASE_URL}/devices`);
+  const data = await handleResponse(response);
+  return data.devices || [];
+}
+
 export async function sendServiceAction(serviceId, action, reason) {
   const response = await fetch(`${API_BASE_URL}/services/${serviceId}/actions`, {
     method: 'POST',

--- a/client/src/hooks/useDevices.js
+++ b/client/src/hooks/useDevices.js
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchDevices } from '../api.js';
+
+export function useDevices({ enabled = true } = {}) {
+  const [devices, setDevices] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  const load = useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchDevices();
+      setDevices(data);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err.message || 'Unable to load devices');
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return undefined;
+    }
+
+    load();
+    const interval = setInterval(load, 20000);
+    return () => clearInterval(interval);
+  }, [enabled, load]);
+
+  const actions = useMemo(
+    () => ({
+      refresh: load,
+    }),
+    [load],
+  );
+
+  return { devices, loading, error, lastUpdated, ...actions };
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,11 @@ services:
       N8N_WEBHOOK_URL: https://n8n.kweks.co/webhook/04fca9af-9205-4dad-829b-a6a9d110d1a5
       N8N_WEBHOOK_TIMEOUT: ${N8N_WEBHOOK_TIMEOUT:-5000}
       SERVICES_CONFIG_PATH: /app/services.config.json
+      DEVICES_CONFIG_PATH: /app/devices.config.json
       DOCKER_SOCKET_PATH: /var/run/docker.sock
     volumes:
       - ./server/services.config.json:/app/services.config.json:ro
+      - ./server/devices.config.json:/app/devices.config.json:ro
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - "3033:3001"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,6 +11,7 @@ This document summarises how to configure the admin dashboard services without t
 | `N8N_WEBHOOK_TIMEOUT` | Request timeout, in milliseconds (defaults to `5000`). |
 | `N8N_WEBHOOK_HEADERS` | JSON object encoded as a string that is merged into the webhook request headers. |
 | `SERVICES_CONFIG_PATH` | Absolute path to the JSON configuration file describing Docker Compose services. |
+| `DEVICES_CONFIG_PATH` | Absolute path to the JSON configuration file describing monitored devices. |
 | `DOCKER_SOCKET_PATH` | Path to the Docker Engine socket (defaults to `/var/run/docker.sock`). |
 
 ## Service configuration
@@ -85,3 +86,32 @@ When a user requests an action, the backend posts a JSON payload like the follow
 N8N can use the `commands` map to execute shell steps or trigger other automation flows.
 
 The API response sent back to the dashboard mirrors this payload (with webhook response metadata) so operators can see what was dispatched.
+
+## Device configuration
+
+Devices monitored via the dashboard are read from `server/devices.config.json` (or the path specified by
+`DEVICES_CONFIG_PATH`). Each entry describes a Windows machine to monitor via ICMP ping.
+
+```json
+[
+  {
+    "id": "ops-desktop",
+    "label": "Operations Desktop",
+    "description": "Primary Windows workstation for the ops team",
+    "type": "windows",
+    "address": "192.168.1.50",
+    "pingCount": 1,
+    "timeoutMs": 4000
+  }
+]
+```
+
+### Device fields
+
+- `id`, `label`, and `address` are required.
+- `description` and `type` are optional metadata displayed in the UI.
+- `pingCount` and `timeoutMs` allow tuning how many pings are attempted and how long (in milliseconds) the server waits for a reply.
+
+When the dashboard requests `/api/devices`, the backend pings each configured address. Devices that respond are marked `online`,
+and the response latency is reported when available. Devices that do not respond are marked `offline`, and the backend remembers
+the most recent time a successful ping was observed so operators can see when a machine was last reachable.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,6 +10,7 @@ RUN npm install --omit=dev && npm cache clean --force
 # Copy source code
 COPY src ./src
 COPY services.config.json ./services.config.json
+COPY devices.config.json ./devices.config.json
 
 ENV NODE_ENV=production
 ENV PORT=3001

--- a/server/devices.config.json
+++ b/server/devices.config.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "ops-desktop",
+    "label": "Operations Desktop",
+    "description": "Primary Windows workstation for the ops team",
+    "type": "windows",
+    "address": "192.168.1.50",
+    "pingCount": 1,
+    "timeoutMs": 4000
+  },
+  {
+    "id": "warehouse-terminal",
+    "label": "Warehouse Terminal",
+    "description": "Front-of-house PC used for order fulfilment",
+    "type": "windows",
+    "address": "192.168.1.51"
+  }
+]

--- a/server/src/deviceService.js
+++ b/server/src/deviceService.js
@@ -1,0 +1,153 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DEFAULT_DEVICES_CONFIG_PATH = process.env.DEVICES_CONFIG_PATH
+  ? path.resolve(process.env.DEVICES_CONFIG_PATH)
+  : path.resolve(__dirname, '..', 'devices.config.json');
+
+const lastKnownOnline = new Map();
+
+function resolveDeviceTimeout(device) {
+  if (!device) return 4000;
+  const timeout = Number(device.timeoutMs);
+  if (Number.isFinite(timeout) && timeout > 0) {
+    return timeout;
+  }
+  return 4000;
+}
+
+function resolveDevicePingCount(device) {
+  if (!device) return 1;
+  const count = Number(device.pingCount);
+  if (Number.isInteger(count) && count > 0) {
+    return count;
+  }
+  return 1;
+}
+
+function buildPingArgs(address, options = {}) {
+  const { timeoutMs = 4000, count = 1 } = options;
+  const platform = process.platform;
+  if (platform === 'win32') {
+    return ['-n', String(count), '-w', String(timeoutMs), address];
+  }
+  const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+  return ['-n', '-c', String(count), '-w', String(timeoutSeconds), address];
+}
+
+function parsePingLatency(output) {
+  if (!output) return null;
+  const match = output.match(/time[=<]([\d.]+)\s*ms/i);
+  if (!match) return null;
+  const value = Number.parseFloat(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+function extractErrorDetail(error) {
+  if (!error) return null;
+  if (error.code === 'ENOENT') {
+    return 'ping command is not available on the server host';
+  }
+  if (error.killed) {
+    return 'Ping command timed out before a reply was received';
+  }
+  const combined = [error.stdout, error.stderr]
+    .filter((chunk) => typeof chunk === 'string' && chunk.trim().length > 0)
+    .join('\n');
+  if (!combined) {
+    return 'Host did not respond to ping';
+  }
+  const lines = combined.trim().split('\n');
+  return lines[lines.length - 1];
+}
+
+async function loadDevicesConfig() {
+  const raw = await fs.readFile(DEFAULT_DEVICES_CONFIG_PATH, 'utf-8');
+  const devices = JSON.parse(raw);
+  if (!Array.isArray(devices)) {
+    throw new Error('devices.config.json must export an array');
+  }
+  return devices;
+}
+
+async function checkDeviceStatus(device) {
+  const checkedAt = new Date();
+  if (!device.address) {
+    return {
+      state: 'unknown',
+      detail: 'No address configured for this device',
+      lastChecked: checkedAt.toISOString(),
+      lastOnline: lastKnownOnline.get(device.id) || null,
+      latencyMs: null,
+    };
+  }
+
+  const timeoutMs = resolveDeviceTimeout(device);
+  const pingCount = resolveDevicePingCount(device);
+  const args = buildPingArgs(device.address, { timeoutMs, count: pingCount });
+
+  try {
+    const { stdout, stderr } = await execFileAsync('ping', args, {
+      timeout: timeoutMs + 1000,
+      windowsHide: true,
+    });
+    const latency = parsePingLatency(stdout) ?? parsePingLatency(stderr);
+    const lastOnline = checkedAt.toISOString();
+    lastKnownOnline.set(device.id, lastOnline);
+    return {
+      state: 'online',
+      detail: 'Device responded to ICMP ping',
+      lastChecked: checkedAt.toISOString(),
+      lastOnline,
+      latencyMs: latency ?? null,
+    };
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return {
+        state: 'unknown',
+        detail: 'ping command is not available on the server host',
+        lastChecked: checkedAt.toISOString(),
+        lastOnline: lastKnownOnline.get(device.id) || null,
+        latencyMs: null,
+      };
+    }
+
+    const detail = extractErrorDetail(error);
+    return {
+      state: 'offline',
+      detail: detail || 'Device did not respond to ping',
+      lastChecked: checkedAt.toISOString(),
+      lastOnline: lastKnownOnline.get(device.id) || null,
+      latencyMs: null,
+    };
+  }
+}
+
+export async function getDevices() {
+  return loadDevicesConfig();
+}
+
+export async function getDevicesWithStatus() {
+  const devices = await loadDevicesConfig();
+  const withStatus = await Promise.all(
+    devices.map(async (device) => ({
+      ...device,
+      status: await checkDeviceStatus(device),
+    })),
+  );
+  return withStatus;
+}
+
+export async function findDeviceById(id) {
+  if (!id) return null;
+  const devices = await loadDevicesConfig();
+  return devices.find((device) => device.id === id) || null;
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,7 @@ import {
   setDesiredState,
   buildActionContext,
 } from './dockerService.js';
+import { getDevicesWithStatus } from './deviceService.js';
 
 dotenv.config();
 
@@ -66,6 +67,18 @@ app.get('/api/services', async (req, res) => {
   } catch (error) {
     res.status(500).json({
       error: 'Unable to load services',
+      detail: error.message,
+    });
+  }
+});
+
+app.get('/api/devices', async (req, res) => {
+  try {
+    const devices = await getDevicesWithStatus();
+    res.json({ devices });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Unable to load devices',
       detail: error.message,
     });
   }


### PR DESCRIPTION
## Summary
- add a device monitoring service that pings configured Windows machines and surfaces their status via `/api/devices`
- include a new devices.json config file and wire it into the Docker image/compose deployment
- extend the React dashboard with a tabbed layout and a devices table that shows reachability, latency, and last-online info

## Testing
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68e05e49ff6c8329bb148bff77925af1