### PR TITLE
Add build option to service actions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -226,6 +226,11 @@ tr + tr td {
   color: #052e16;
 }
 
+.btn-build {
+  background: linear-gradient(135deg, #38bdf8, #0284c7);
+  color: #f0f9ff;
+}
+
 .btn-down {
   background: linear-gradient(135deg, #ef4444, #b91c1c);
   color: #fee2e2;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -124,6 +124,13 @@ function ServiceRow({ service, onAction, busyId }) {
               Bring Up
             </button>
             <button
+              className="btn btn-build"
+              onClick={() => handleAction('build')}
+              disabled={isBusy}
+            >
+              Build & Up
+            </button>
+            <button
               className="btn btn-down"
               onClick={() => handleAction('down')}
               disabled={isBusy}

--- a/server/src/dockerService.js
+++ b/server/src/dockerService.js
@@ -93,6 +93,10 @@ function composeCommandForAction(service, action) {
       args.push('up', '-d');
       args.push(...targets);
       break;
+    case 'build':
+      args.push('up', '--build', '-d');
+      args.push(...targets);
+      break;
     case 'down':
       // Use stop instead of down to avoid tearing down the whole project
       args.push('stop');
@@ -150,7 +154,7 @@ export function buildActionContext(service) {
     services: composeServiceTarget(service),
   };
 
-  const commands = ['up', 'down', 'restart'].reduce((acc, action) => {
+  const commands = ['up', 'build', 'down', 'restart'].reduce((acc, action) => {
     const command = composeCommandForAction(service, action);
     if (command) {
       acc[action] = command;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -87,9 +87,9 @@ app.get('/api/devices', async (req, res) => {
 app.post('/api/services/:id/actions', async (req, res) => {
   const { id } = req.params;
   const { action, reason } = req.body;
-  if (!action || !['up', 'down', 'restart'].includes(action)) {
+  if (!action || !['up', 'build', 'down', 'restart'].includes(action)) {
     return res.status(400).json({
-      error: "Action must be one of 'up', 'down', or 'restart'",
+      error: "Action must be one of 'up', 'build', 'down', or 'restart'",
     });
   }
 


### PR DESCRIPTION
## Summary
- add a Build & Up action to each service row in the dashboard
- style the new build control alongside existing buttons
- allow the API to accept build requests and surface the compose command

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f57c2285648329988543382e8781d8